### PR TITLE
chore: build backend only

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -5,6 +5,8 @@ This application is deployed as two separate services:
 - **Frontend**: React app on Vercel
 - **Backend**: Node.js/Express API on Railway/Render/Heroku
 
+`npm run build` now compiles only the backend service (`npm run build:backend`). If deploying the frontend separately, configure your environment to run `npm run build:frontend` or `cd frontend && npm install && npm run build` (e.g., via Vercel's `buildCommand`).
+
 ## Frontend Deployment (Vercel)
 
 ### 1. Connect to Vercel

--- a/VERCEL_DEPLOYMENT.md
+++ b/VERCEL_DEPLOYMENT.md
@@ -37,6 +37,8 @@ Follow the prompts to:
 2. Import your Git repository
 3. Vercel will auto-detect the configuration from `vercel.json`
 
+The root `npm run build` script only builds the backend (`npm run build:backend`). Vercel's `vercel.json` handles the frontend build with `cd frontend && npm install && npm run build`. If you deploy the frontend using another provider, override its build command accordingly.
+
 ### 4. Configure Environment Variables
 
 In Vercel Dashboard > Settings > Environment Variables, add:

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev:local": "./scripts/start-local.sh",
     "dev:backend": "cd backend && npm run dev",
     "dev:frontend": "cd frontend && npm run dev",
-    "build": "npm run build:backend && npm run build:frontend",
+    "build": "npm run build:backend",
     "build:backend": "cd backend && npm run build",
     "build:frontend": "cd frontend && npm run build",
     "start": "cd backend && npm run start",


### PR DESCRIPTION
## Summary
- build script now only compiles the backend service
- document separate frontend build pipeline and example override

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 42 problems, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68925ace84b483248b6367547edcf4b6